### PR TITLE
Remove dangling curl hyphen

### DIFF
--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -366,7 +366,7 @@ namespace WebFileFetcher {
     auto PathName = Path + filename;
 
     std::string BigArgs =
-    fmt::format("curl - {} -o {}", URL, PathName);
+    fmt::format("curl {} -o {}", URL, PathName);
     std::vector<const char*> ExecveArgs = {
       "/bin/sh",
       "-c",


### PR DESCRIPTION
Fixes a regression in fa87c73b9ee60a334eace2cdc3097725cbaf5b88; curl complains "curl: option -: is unknown" when trying to fetch a RootFS without this.